### PR TITLE
Bump all dependencies to their latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ webrtc-extensions = []
 tokio-codec = ["tokio-util"]
 
 [build-dependencies]
-protobuf-codegen-pure = "2.25"
+protobuf-codegen = "3"
 
 [dependencies]
 bytes = "1.0"
 byteorder = "1"
-tokio-util = { version = "0.6", features = ["codec"], optional = true }
-asynchronous-codec = { version = "0.6.0", optional = true }
-protobuf = "2"
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
+asynchronous-codec = { version = "0.7", optional = true }
+protobuf = "3"
 openssl = { version = "0.10", optional = true }
 cfg-if = "1.0.0"
 
@@ -32,5 +32,5 @@ argparse = "0.2"
 futures = "0.3"
 native-tls = "0.2"
 tokio = { version = "1.0", features = ["full"] }
-tokio-util = { version = "0.6", features = ["codec", "net"] }
+tokio-util = { version = "0.7", features = ["codec", "net"] }
 tokio-native-tls = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let out_dir = Path::new(&env::var("OUT_DIR").unwrap()).join("proto");
     fs::create_dir_all(&out_dir).expect("Failed to create $OUT_DIR/proto directory");
 
-    protobuf_codegen_pure::Codegen::new()
+    protobuf_codegen::Codegen::new()
         .out_dir(&out_dir)
         .inputs(&[if cfg!(feature = "webrtc-extensions") {
             "protos/MumbleWithWebRTC.proto"
@@ -16,10 +16,9 @@ fn main() {
             "protos/Mumble.proto"
         }])
         .includes(&["protos"])
-        .customize(protobuf_codegen_pure::Customize {
-            generate_accessors: Some(true),
-            ..Default::default()
-        })
+        .customize(protobuf_codegen::Customize::default()
+            .generate_accessors(true)
+        )
         .run()
         .expect("protoc");
 

--- a/examples/echo_client.rs
+++ b/examples/echo_client.rs
@@ -70,25 +70,25 @@ async fn connect(
             ControlPacket::TextMessage(mut msg) => {
                 println!(
                     "Got message from user with session ID {}: {}",
-                    msg.get_actor(),
-                    msg.get_message()
+                    msg.actor(),
+                    msg.message()
                 );
                 // Send reply back to server
                 let mut response = msgs::TextMessage::new();
-                response.mut_session().push(msg.get_actor());
+                response.mut_session().push(msg.actor());
                 response.set_message(msg.take_message());
                 sink.send(response.into()).await.unwrap();
             }
             ControlPacket::CryptSetup(msg) => {
                 // Wait until we're fully connected before initiating UDP voice
                 crypt_state = Some(ClientCryptState::new_from(
-                    msg.get_key()
+                    msg.key()
                         .try_into()
                         .expect("Server sent private key with incorrect size"),
-                    msg.get_client_nonce()
+                    msg.client_nonce()
                         .try_into()
                         .expect("Server sent client_nonce with incorrect size"),
-                    msg.get_server_nonce()
+                    msg.server_nonce()
                         .try_into()
                         .expect("Server sent server_nonce with incorrect size"),
                 ));

--- a/src/control.rs
+++ b/src/control.rs
@@ -10,7 +10,7 @@ use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
-use protobuf::error::ProtobufError;
+use protobuf::Error as ProtobufError;
 use protobuf::Message;
 
 use crate::voice::Clientbound;
@@ -337,10 +337,10 @@ macro_rules! define_packet_from {
                 if packet.id == msgs::id::$name {
                     Self::try_from(packet.bytes)
                 } else {
-                    Err(ProtobufError::IoError(io::Error::new(
+                    Err(io::Error::new(
                         io::ErrorKind::Other,
                         concat!("expected packet of type ", stringify!($name)),
-                    )))
+                    ).into())
                 }
             }
         }


### PR DESCRIPTION
Only protobuf required code changes, the `get_*` accessors lost their `get_` prefix, `protobuf::error::ProtobufError` got renamed into `protobuf::Error`, and protobuf-codegen-pure got renamed protobuf-codegen.