### PR TITLE
Update Mumble.proto from the Mumble master

### DIFF
--- a/protos/Mumble.proto
+++ b/protos/Mumble.proto
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
@@ -10,8 +10,12 @@ package MumbleProto;
 option optimize_for = SPEED;
 
 message Version {
-	// 2-byte Major, 1-byte Minor and 1-byte Patch version number.
-	optional uint32 version = 1;
+	// Legacy version number format.
+	optional uint32 version_v1 = 1;
+	// New version number format.
+	// Necessary since patch level may exceed 255. (See https://github.com/mumble-voip/mumble/issues/5827)
+	optional uint64 version_v2 = 5;
+
 	// Client release name.
 	optional string release = 2;
 	// Client OS name.
@@ -37,6 +41,8 @@ message Authenticate {
 	// A list of CELT bitstream version constants supported by the client.
 	repeated int32 celt_versions = 4;
 	optional bool opus = 5 [default = false];
+	// 0 = REGULAR, 1 = BOT
+	optional int32 client_type = 6 [default = 0];
 }
 
 // Sent by the client to notify the server that the client is still alive.
@@ -107,6 +113,9 @@ message ServerSync {
 	// Server welcome text.
 	optional string welcome_text = 3;
 	// Current user permissions in the root channel.
+	// Note: The permissions data type usually is uin32 (e.g. in PermissionQuery and PermissionDenied messages). Here
+	// it is uint64 because of an oversight in the past. Nonetheless it should never exceed the uin32 range.
+	// See also: https://github.com/mumble-voip/mumble/issues/5139
 	optional uint64 permissions = 4;
 }
 
@@ -172,6 +181,11 @@ message UserRemove {
 // First seen during login procedure. May be sent by the client when it wishes
 // to alter its state.
 message UserState {
+	message VolumeAdjustment {
+		optional uint32 listening_channel = 1;
+		optional float volume_adjustment = 2;
+	}
+
 	// Unique user session ID of the user whose state this is, may change on
 	// reconnect.
 	optional uint32 session = 1;
@@ -223,6 +237,8 @@ message UserState {
 	repeated uint32 listening_channel_add = 21;
 	// a list of channels the user does no longer want to listen to.
 	repeated uint32 listening_channel_remove = 22;
+	// A list of volume adjustments the user has applied to listeners
+	repeated VolumeAdjustment listening_volume_adjustment = 23;
 }
 
 // Relays information on the bans. The client may send the BanList message to
@@ -571,13 +587,19 @@ message ServerConfig {
 	optional uint32 image_message_length = 5;
 	// The maximum number of users allowed on the server.
 	optional uint32 max_users = 6;
+	// Whether using Mumble's recording feature is allowed on the server
+	optional bool recording_allowed = 7;
 }
 
 // Sent by the server to inform the clients of suggested client configuration
 // specified by the server administrator.
 message SuggestConfig {
-	// Suggested client version.
-	optional uint32 version = 1;
+	// Suggested client version in the legacy format.
+	optional uint32 version_v1 = 1;
+	// Suggested client version in the new format.
+	// Necessary since patch level may exceed 255. (See https://github.com/mumble-voip/mumble/issues/5827)
+	optional uint64 version_v2 = 4;
+
 	// True if the administrator suggests positional audio to be used on this
 	// server.
 	optional bool positional = 2;


### PR DESCRIPTION
This was taken from [master on the 2024-11-09](https://github.com/mumble-voip/mumble/commit/9c4856185c6c99c5bb3eaa983b757bb0a9431ccb).

I’m worried about the compatibility with [MumbleWithWebRTC.proto](https://github.com/2xsaiko/rust-mumble-protocol/blob/master/protos/MumbleWithWebRTC.proto), which uses fields which are now used by the upstream protocol. See [its issue upstream](https://github.com/mumble-voip/mumble/issues/3561), which hasn’t been updated in four years.