### PR TITLE
Update to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Marco Rebhan <me@dblsaiko.net>",
   "Jonas Herzig <me@johni0702.de>"
 ]
-edition = "2018"
+edition = "2021"
 description = "Rust implementation of the Mumble protocol"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/2xsaiko/rust-mumble-protocol"

--- a/examples/echo_client.rs
+++ b/examples/echo_client.rs
@@ -12,8 +12,6 @@ use mumble_protocol::control::ControlPacket;
 use mumble_protocol::crypt::ClientCryptState;
 use mumble_protocol::voice::VoicePacket;
 use mumble_protocol::voice::VoicePacketPayload;
-use std::convert::Into;
-use std::convert::TryInto;
 use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,7 +1,5 @@
 //! Control channel messages and codecs
 
-use std::convert::TryFrom;
-use std::convert::TryInto;
 use std::io;
 use std::io::Cursor;
 use std::marker::PhantomData;

--- a/src/crypt.rs
+++ b/src/crypt.rs
@@ -1,6 +1,5 @@
 //! Implementation of the cryptography used for Mumble's voice channel
 
-use std::convert::TryInto;
 use std::io;
 
 use bytes::BytesMut;

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -8,9 +8,6 @@
 //! Both packets are of fixed size and can be converted to/from `u8` arrays/slices via
 //! the respective `From`/`TryFrom` impls.
 
-use std::convert::TryFrom;
-use std::convert::TryInto;
-
 /// A ping packet sent to the server.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PingPacket {


### PR DESCRIPTION
This lets us remove imports from `std::convert`.